### PR TITLE
docs: add unofficial AUR package to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,8 @@ Currently supported versions: **6.5**
   ```
 </details>
 
-**\* Unofficial package, use at your own risk.**
-
 <details>
-  <summary>Arch Linux (AUR)</summary>
+  <summary>Arch Linux (AUR)*</summary>
   <br>
   
   ```sh


### PR DESCRIPTION
Hello, I've packaged Better Blur DX (BBDX) for Arch Linux.[^1] This PR serves to inform other Arch Linux users that BBDX is packaged for their distro by listing it in the packages section.

Also thanks for creating this fork, you're a life saver lol.

P.S. Could you also enable issues on this repository?

[^1]: https://aur.archlinux.org/packages/kwin-effects-better-blur-dx-git