### PR TITLE
Avoid force blurring unknown undecorated popups

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -287,6 +287,16 @@ bool BBDX::Window::neverForceBlur() const {
         && (layer == KWin::Layer::OverlayLayer || layer == KWin::Layer::ActiveLayer))
         return true;
 
+    // Some application-managed popups (notably browser extension panels on Wayland)
+    // show up as undecorated Unknown windows with no caption. They don't expose a
+    // useful opaque region to the compositor, so force-blurring them produces a
+    // rectangular halo around the popup body.
+    if (effectwindow()->windowType() == KWin::WindowType::Unknown
+        && !effectwindow()->hasDecoration()
+        && effectwindow()->caption().isEmpty()) {
+        return true;
+    }
+
     // don't touch KWin internal windows
     // this includes the snapping assistant zones
     // and they don't handle blur well at all


### PR DESCRIPTION
## Summary

Avoid force blurring application-managed Wayland popups that show up as:

- `WindowType::Unknown`
- undecorated
- empty caption

These windows may not expose a useful opaque region to KWin. Force-blurring them
causes a rectangular blur halo around the popup body, which is especially visible
with browser extension panels such as 1Password in Zen Browser.

## What changed

- Add a guard in `BBDX::Window::neverForceBlur()` to skip force blur for unknown,
  undecorated, captionless popups.

## Why

During debugging, the problematic Zen popup was exposed to KWin as a separate
`zen` window with:

- `WindowType::Unknown`
- no decoration
- empty caption
- no useful opaque region

Because Better Blur DX treated it as a regular force-blurred window, the entire
rectangular popup surface was blurred, creating the visible halo.

## Validation

- Reproduced with Zen Browser on Plasma Wayland
- Confirmed the popup was not classified as `PopupMenu`, `DropdownMenu`, or `Tooltip`
- Verified the halo disappeared after excluding this class of windows from force blur
