### PR TITLE
Fixed missing header for Plasma 6.6.4

### DIFF
--- a/src/blur.h
+++ b/src/blur.h
@@ -29,6 +29,9 @@
 #include <opengl/glutils.h>
 #include <scene/item.h>
 #include <scene/scene.h>
+#if KWIN_VERSION >= KWIN_VERSION_CODE(6, 6, 4)
+#include <scene/backgroundeffectitem.h>
+#endif
 #include <window.h>
 
 #include <QList>


### PR DESCRIPTION
I updated to kde-plasma/kwin-6.6.4 and this effect can't compile anymore.
```
> make -j 16
[  0%] Built target better_blur_dx_autogen_timestamp_deps
[  0%] Built target kwin_better_blur_dx_config_autogen_timestamp_deps
[  3%] Automatic MOC for target better_blur_dx
[  6%] Automatic MOC for target kwin_better_blur_dx_config
AutoMoc warning
---------------
"SRC:/src/main.cpp"
includes the moc file "main.moc", but does not contain a Q_OBJECT, Q_GADGET, Q_NAMESPACE, Q_NAMESPACE_EXPORT, Q_GADGET_EXPORT, Q_ENUM_NS, K_PLUGIN_FACTORY, K_PLUGIN_CLASS, K_PLUGIN_FACTORY_WITH_JSON or K_PLUGIN_CLASS_WITH_JSON macro.

[  6%] Built target kwin_better_blur_dx_config_autogen
[ 17%] Automatic RCC for blur_config.qrc
[ 17%] Generating blurconfig.h, blurconfig.cpp
[ 17%] Generating ui_blur_config.h
[ 20%] Generating kwineffects_interface.cpp, kwineffects_interface.h
[ 24%] Generating moc_kwineffects_interface.cpp
[ 24%] Built target better_blur_dx_autogen
[ 27%] Generating blurconfig.h, blurconfig.cpp
[ 31%] Automatic RCC for blur.qrc
[ 34%] Building CXX object src/CMakeFiles/better_blur_dx.dir/better_blur_dx_autogen/mocs_compilation.cpp.o
[ 41%] Building CXX object src/CMakeFiles/better_blur_dx.dir/main.cpp.o
[ 41%] Building CXX object src/CMakeFiles/better_blur_dx.dir/blur_cache.cpp.o
[ 44%] Building CXX object src/CMakeFiles/better_blur_dx.dir/settings.cpp.o
[ 48%] Building CXX object src/CMakeFiles/better_blur_dx.dir/blur.cpp.o
[ 51%] Building CXX object src/CMakeFiles/better_blur_dx.dir/refraction_pass.cpp.o
[ 58%] Building CXX object src/CMakeFiles/better_blur_dx.dir/rounded_corners_pass.cpp.o
[ 58%] Building CXX object src/CMakeFiles/better_blur_dx.dir/window.cpp.o
[ 62%] Building CXX object src/CMakeFiles/better_blur_dx.dir/blurconfig.cpp.o
[ 65%] Building CXX object src/CMakeFiles/better_blur_dx.dir/better_blur_dx_autogen/EWIEGA46WW/qrc_blur.cpp.o
[ 68%] Building CXX object src/CMakeFiles/better_blur_dx.dir/window_manager.cpp.o
[ 72%] Building CXX object src/kcm/CMakeFiles/kwin_better_blur_dx_config.dir/blurconfig.cpp.o
[ 75%] Building CXX object src/kcm/CMakeFiles/kwin_better_blur_dx_config.dir/blur_config.cpp.o
[ 79%] Building CXX object src/kcm/CMakeFiles/kwin_better_blur_dx_config.dir/kwineffects_interface.cpp.o
[ 86%] Building CXX object src/kcm/CMakeFiles/kwin_better_blur_dx_config.dir/kwin_better_blur_dx_config_autogen/mocs_compilation.cpp.o
[ 86%] Building CXX object src/kcm/CMakeFiles/kwin_better_blur_dx_config.dir/kwin_better_blur_dx_config_autogen/EWIEGA46WW/qrc_blur_config.cpp.o
In file included from /home/tohka/GitHub/kwin-effects-better-blur-dx/src/window_manager.cpp:1:
In file included from /home/tohka/GitHub/kwin-effects-better-blur-dx/src/window_manager.hpp:4:
In file included from /home/tohka/GitHub/kwin-effects-better-blur-dx/src/window.hpp:5:
In file included from /usr/include/qt6/QtCore/QObject:1:
In file included from /usr/include/qt6/QtCore/qobject.h:10:
In file included from /usr/include/qt6/QtCore/qobjectdefs.h:13:
In file included from /usr/include/qt6/QtCore/qobjectdefs_impl.h:17:
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/memory:78:
/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/unique_ptr.h:90:16: error: invalid application of
      'sizeof' to an incomplete type 'KWin::BackgroundEffectItem'
   90 |         static_assert(sizeof(_Tp)>0,
      |                       ^~~~~~~~~~~
/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/unique_ptr.h:398:4: note: in instantiation of member
      function 'std::default_delete<KWin::BackgroundEffectItem>::operator()' requested here
  398 |           get_deleter()(std::move(__ptr));
      |           ^
/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/type_traits:1312:43: note: in instantiation of member
      function 'std::unique_ptr<KWin::BackgroundEffectItem>::~unique_ptr' requested here
 1312 |       = requires (void(&__f)(_Tp)) { __f({}); };
      |                                           ^
/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/type_traits:1312:38: note: in instantiation of
      requirement here
 1312 |       = requires (void(&__f)(_Tp)) { __f({}); };
      |                                      ^~~~~~~
/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/type_traits:1316:23: note: in instantiation of variable
      template specialization 'std::__is_implicitly_default_constructible_v<KWin::BlurEffectData>' requested here
 1316 |     : __bool_constant<__is_implicitly_default_constructible_v<_Tp>>
      |                       ^
/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/type_traits:183:30: note: in instantiation of template
      class 'std::__is_implicitly_default_constructible<KWin::BlurEffectData>' requested here
  183 |                                       __enable_if_t<bool(_Bn::value)>...>;
      |                                                          ^
/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/type_traits:199:16: note: while substituting
      explicitly-specified template arguments into function template '__and_fn'
  199 |     : decltype(__detail::__and_fn<_Bn...>(0))
      |                ^
/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/type_traits:204:29: note: in instantiation of template
      class 'std::__and_<std::__is_implicitly_default_constructible<KWin::EffectWindow *const>,
      std::__is_implicitly_default_constructible<KWin::BlurEffectData>>' requested here
  204 |     : __bool_constant<!bool(_Pp::value)>
      |                             ^
/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/stl_pair.h:344:16: note: in instantiation of
      template class 'std::__not_<std::__and_<std::__is_implicitly_default_constructible<KWin::EffectWindow *const>,
      std::__is_implicitly_default_constructible<KWin::BlurEffectData>>>' requested here
  344 |       explicit(__not_<__and_<__is_implicitly_default_constructible<_T1>,
      |                ^
/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/hashtable_policy.h:436:7: note: in instantiation of
      template class 'std::pair<KWin::EffectWindow *const, KWin::BlurEffectData>' requested here
  436 |       operator==(const _Node_iterator&, const _Node_iterator&) = default;
      |       ^
/home/tohka/GitHub/kwin-effects-better-blur-dx/src/window_manager.cpp:272:39: note: in instantiation of
      template class 'std::__detail::_Node_iterator<std::pair<KWin::EffectWindow *const, KWin::BlurEffectData>, false, false>'
      requested here
  272 |     if (auto it = m_effect->m_windows.find(w); it != m_effect->m_windows.end()) {
      |                                       ^
/home/tohka/GitHub/kwin-effects-better-blur-dx/src/blur.h:44:7: note: forward declaration of
      'KWin::BackgroundEffectItem'
   44 | class BackgroundEffectItem;
      |       ^
1 error generated.
make[2]: *** [src/CMakeFiles/better_blur_dx.dir/build.make:239: src/CMakeFiles/better_blur_dx.dir/window_manager.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:199: src/CMakeFiles/better_blur_dx.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 89%] Linking CXX shared module kwin_better_blur_dx_config.so
[ 93%] Built target kwin_better_blur_dx_config
make: *** [Makefile:166: all] Error 2
```

This pull request add the missing header for this version of Kwin.