### PR TITLE
Add more libxcb- packages to debian install deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,12 @@ KWin X11 doesn't see any API changes since version 6.5 meaning the Wayland and X
 
   Wayland:
   ```
-  sudo apt install -y git cmake g++ extra-cmake-modules qt6-tools-dev kwin-dev libkf6configwidgets-dev gettext libkf6crash-dev libkf6globalaccel-dev libkf6kio-dev libkf6service-dev libkf6notifications-dev libkf6kcmutils-dev libkdecorations3-dev libxcb-composite0-dev libxcb-randr0-dev libxcb-shm0-dev
+  sudo apt install -y git cmake g++ extra-cmake-modules qt6-tools-dev kwin-dev libkf6configwidgets-dev gettext libkf6crash-dev libkf6globalaccel-dev libkf6kio-dev libkf6service-dev libkf6notifications-dev libkf6kcmutils-dev libkdecorations3-dev libxcb-composite0-dev libxcb-randr0-dev libxcb-shm0-dev libxcb-res0-dev libxcb-sync-dev
   ```
   
   X11:
   ```
-  sudo apt install -y git cmake g++ extra-cmake-modules qt6-tools-dev kwin-x11-dev libkf6configwidgets-dev gettext libkf6crash-dev libkf6globalaccel-dev libkf6kio-dev libkf6service-dev libkf6notifications-dev libkf6kcmutils-dev libkdecorations3-dev libxcb-composite0-dev libxcb-randr0-dev libxcb-shm0-dev
+  sudo apt install -y git cmake g++ extra-cmake-modules qt6-tools-dev kwin-x11-dev libkf6configwidgets-dev gettext libkf6crash-dev libkf6globalaccel-dev libkf6kio-dev libkf6service-dev libkf6notifications-dev libkf6kcmutils-dev libkdecorations3-dev libxcb-composite0-dev libxcb-randr0-dev libxcb-shm0-dev libxcb-res0-dev libxcb-sync-dev
   ```
 </details>
 


### PR DESCRIPTION
/usr/include/kwin/x11window.h:28:10: fatal error: xcb/res.h: No such file or directory
   28 | #include <xcb/res.h>
      |          ^~~~~~~~~~~

/usr/include/kwin/x11window.h:29:10: fatal error: xcb/sync.h: No such file or directory
   29 | #include <xcb/sync.h>
      |          ^~~~~~~~~~~~