### PR TITLE
Fix Arch build failure caused by QRect/KWin::Rect mismatch

### DIFF
--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -906,12 +906,14 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     } else if (data.xTranslation() || data.yTranslation()) {
         blurShape.translate(std::round(data.xTranslation()), std::round(data.yTranslation()));
     }
+#if KWIN_VERSION < KWIN_VERSION_CODE(6, 5, 80)
     const QRect backgroundRect = blurShape.boundingRect();
     const QRect scaledBackgroundRect = snapToPixelGrid(scaledRect(backgroundRect, viewport.scale()));
-#if KWIN_VERSION < KWIN_VERSION_CODE(6, 5, 80)
     const QRect deviceBackgroundRect = scaledBackgroundRect;
 #else
-    const QRect deviceBackgroundRect = snapToPixelGrid(viewport.mapToDeviceCoordinates(backgroundRect));
+    const Rect backgroundRect = blurShape.boundingRect();
+    const Rect scaledBackgroundRect = backgroundRect.scaled(viewport.scale()).rounded();
+    const Rect deviceBackgroundRect = viewport.mapToDeviceCoordinates(backgroundRect).rounded();
 #endif
 #else
     RegionF blurShape = blurRegion(w);
@@ -955,7 +957,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     if (deviceRegion != Region::infinite()) {
         for (const Rect &clipRect : deviceRegion.rects()) {
             const RectF deviceClipRect = clipRect.translated(-deviceBackgroundRect.topLeft());
-            for (const RectF &shapeRect : blurShape.rects()) {
+            for (const Rect &shapeRect : blurShape.rects()) {
                 const RectF deviceShapeRect = shapeRect.translated(-backgroundRect.topLeft()).scaled(viewport.scale()).rounded();
                 if (const RectF intersected = deviceClipRect.intersected(deviceShapeRect); !intersected.isEmpty()) {
                     effectiveShape.append(intersected);
@@ -963,7 +965,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
             }
         }
     } else {
-        for (const RectF &rect : blurShape.rects()) {
+        for (const Rect &rect : blurShape.rects()) {
             effectiveShape.append(rect.translated(-backgroundRect.topLeft()).scaled(viewport.scale()).rounded());
         }
     }


### PR DESCRIPTION
Fixes #84.

This updates the version-gated blur geometry code to use `KWin::Rect` consistently on newer KWin versions instead of mixing `QRect` with `KWin::Rect`.

What changed:
- use `KWin::Rect` for `backgroundRect`, `scaledBackgroundRect`, and `deviceBackgroundRect` in the affected code path
- update `blurShape.rects()` loops to iterate as `Rect` instead of `RectF`

Why:
- `preparePaintData()` expects `const KWin::Rect *`
- the previous code passed `const QRect *`
- this causes the current Arch build failure reported in #84

Result:
- the project builds successfully again on current Arch/KWin 
- the related range-loop warnings in the same area are also resolved
