### PR TITLE
BlurCache: don't rebuild the cache when dirtyRegion is empty

### DIFF
--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -1029,6 +1029,16 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
 #else
     m_blurCache->preparePaintData(m_currentView, w, &dirtyRegion, renderInfo.framebuffers[0].get(), &backgroundRect, &scaledBackgroundRect, renderInfo.cache);
 
+    // BBDX: If the dirtyRegion doesn't intersect backgroundRect nothing behind the
+    //       window was repainted this frame - the renderTarget only holds stale data
+    //       there. Without a cache entry to fall back on there is nothing valid to
+    //       draw or build a cache entry from, so bail. The on-screen draw would be
+    //       clipped to the deviceRegion anyway.
+    if (dirtyRegion.isEmpty() && !renderInfo.cache.get()) {
+        return;
+    }
+
+    if (!m_blurCache->useCachedOnly()) {
     // BBDX: Always blit the entire backgroundRect to avoid subtle rounding errors on scaled RenderViews.
     //       It took me way too many hours to figure out that this is what's causing sporadic
     //       pixel mismatches during textureCompare...
@@ -1037,6 +1047,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     if (!renderInfo.cache.get() || renderInfo.cache.get()->isFlushing) {
         renderInfo.framebuffers[0]->blitFromRenderTarget(renderTarget, viewport, backgroundRect, backgroundRect.translated(-backgroundRect.topLeft()));
     }
+    } // indent intentional for KWin diff
 #endif
 
     // Upload the geometry: the first 6 vertices are used when downsampling and upsampling offscreen,
@@ -1160,6 +1171,16 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
         return;
     }
 
+#if KWIN_VERSION < KWIN_VERSION_CODE(6, 6, 90)
+    const QMatrix4x4 &colorMatrix = blurInfo.colorMatrix ? *blurInfo.colorMatrix : m_colorMatrix;
+#else
+    const QMatrix4x4 &colorMatrix = m_colorMatrix;
+#endif
+    const float modulation = opacity * opacity;
+
+    // BBDX: without fresh data there is nothing to rebuild the cache from -
+    //       skip all blur passes and only draw the cached texture below
+    if (!m_blurCache->useCachedOnly()) {
     // The downsample pass of the dual Kawase algorithm: the background will be scaled down 50% every iteration.
     {
         ShaderManager::instance()->pushShader(m_downsamplePass.shader.get());
@@ -1220,13 +1241,6 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
 
         ShaderManager::instance()->popShader();
     }
-
-#if KWIN_VERSION < KWIN_VERSION_CODE(6, 6, 90)
-    const QMatrix4x4 &colorMatrix = blurInfo.colorMatrix ? *blurInfo.colorMatrix : m_colorMatrix;
-#else
-    const QMatrix4x4 &colorMatrix = m_colorMatrix;
-#endif
-    const float modulation = opacity * opacity;
 
 #if BETTERBLUR_NOT_NEEDED
     if (const BorderRadius cornerRadius = w->window()->borderRadius(); !cornerRadius.isNull()) {
@@ -1362,6 +1376,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     if (const BorderRadius cornerRadius = m_windowManager->getEffectiveBorderRadius(w); !cornerRadius.isNull()) {
         m_roundedCornersPass->apply(cornerRadius, viewport, scaledBackgroundRect, renderInfo, w, data, vbo, m_blurCache.get());
     }
+    } // indent intentional for KWin diff
 
     // BBDX:
     m_blurCache->drawCached(viewport, renderInfo, vbo, vertexCount, modulation);

--- a/src/blur_cache.cpp
+++ b/src/blur_cache.cpp
@@ -220,6 +220,11 @@ void BBDX::BlurCache::preparePaintData(const KWin::RenderView *view,
     m_paintData.scaledBackgroundRect = scaledBackgroundRect;
     m_paintData.glBeginConditionalRenderCalled = false;
 
+    // BBDX: nothing inside backgroundRect was repainted this frame but we have a
+    //       cache entry - there are no fresh pixels to compare against or blur,
+    //       so BlurEffect::blur() only draws the cached texture (useCachedOnly()).
+    m_paintData.useCachedOnly = cache.get() && dirtyRegion->isEmpty();
+
     // the cache entry needs to stay in sync
     // so BlurCacheEntry::localDirtyRegion() returns
     // correct info
@@ -301,6 +306,15 @@ void BBDX::BlurCache::prepareCache(BBDX::BlurCacheLRU &cache) {
 
     // only proceed if marked in flushAccumulatedDirtyRegions()
     if (!cacheEntry->isFlushing) {
+        return;
+    }
+
+    // BBDX: a flush frame can still have an empty dirtyRegion when KWin paints
+    //       the window with damage that doesn't intersect backgroundRect (e.g.
+    //       shadow-only damage on focus change). There is no blitted data to
+    //       compare against - skip the compare and conditional render setup,
+    //       BlurEffect::blur() only draws the cached texture in this case.
+    if (useCachedOnly()) {
         return;
     }
 

--- a/src/blur_cache.hpp
+++ b/src/blur_cache.hpp
@@ -184,6 +184,11 @@ private:
         // on first paint before we have a usuable cache entry
         // we won't call glBeginConditionalRender
         bool glBeginConditionalRenderCalled{false};
+
+        // nothing inside backgroundRect is repainted this paint
+        // but we have a valid cache entry - there is no fresh data
+        // to compare against or blur so just draw the cached texture
+        bool useCachedOnly{false};
     } m_paintData;
 
 public:
@@ -207,6 +212,19 @@ public:
                           const KWin::Rect *backgroundRect,
                           const KWin::Rect *scaledBackgroundRect,
                           BlurCacheLRU &cache);
+
+    /**
+     * Whether this paint should skip the blit and blur passes
+     * and only draw the existing cached texture.
+     *
+     * True when the dirtyRegion doesn't intersect backgroundRect
+     * while a valid cache entry exists. Without fresh pixels there
+     * is nothing to compare against or blur - rebuilding anyway would
+     * recreate the cache from stale data.
+     *
+     * Only valid after preparePaintData() was called.
+     */
+    bool useCachedOnly() const { return m_paintData.useCachedOnly; }
 
     /**
      * Injects the geometry used for the cache, in logical pixels


### PR DESCRIPTION
## Problem

When KWin paints a blurred window with damage that doesn't intersect `backgroundRect` (e.g. shadow-only damage on focus changes, or repaint slop from effects like wobbly windows), the `dirtyRegion` is empty: nothing behind the window was repainted this frame, so there are no fresh pixels to compare against and `prepareCache()` bails before setting up the conditional render.

Previously this caused an **ungated** re-blur: all blur passes ran and `drawToCache()` overwrote the cached texture — the only place the cache was rewritten outside the conditional-render gate. Besides wasting GPU time on every such paint, this rebuilt the cache from the reference blit alone (which can contain never-initialized regions) and re-applied the noise and rounded-corner passes to it.

This is suspected to contribute to blur showing a stale "cached old state" instead of tracking live content behind the window.

## Fix

Track this case as `useCachedOnly` in the paint data and skip the scene blit, all blur passes and the cache writes, only drawing the existing cached texture.

If no cache entry exists yet and there is no fresh data, bail entirely — there is nothing valid to build an entry from, and the on-screen draw is clipped to the `deviceRegion` anyway.

## Notes

- `colorMatrix`/`modulation` declarations were hoisted above the new gate since `drawCached()` needs `modulation` outside it.
- Follows the existing "indent intentional for KWin diff" style for the added braces to keep the diff against upstream kwin minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)