### PR TITLE
Make a proper build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ When building under normal conditions, simply clone the repo and run the include
 ```sh
 git clone https://github.com/xarblu/kwin-effects-better-blur-dx
 cd kwin-effects-better-blur-dx
+chmod +x build.sh
 ./build.sh
 ```
 
@@ -224,6 +225,7 @@ To build a version for KWin X11, run the script with the `--x11` flag.
   # enter container
   git clone https://github.com/xarblu/kwin-effects-better-blur-dx
   cd kwin-effects-better-blur-dx
+  chmod +x build.sh
   ./build.sh --kinoite
   exit # exit container
   sudo rpm-ostree install kwin-effects-better-blur-dx/build/kwin-better-blur-dx.rpm

--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ When building under normal conditions, simply clone the repo and run the include
 ```sh
 git clone https://github.com/xarblu/kwin-effects-better-blur-dx
 cd kwin-effects-better-blur-dx
-chmod +x build.sh
 ./build.sh
 ```
 
@@ -225,7 +224,6 @@ To build a version for KWin X11, run the script with the `--x11` flag.
   # enter container
   git clone https://github.com/xarblu/kwin-effects-better-blur-dx
   cd kwin-effects-better-blur-dx
-  chmod +x build.sh
   ./build.sh --kinoite
   exit # exit container
   sudo rpm-ostree install kwin-effects-better-blur-dx/build/kwin-better-blur-dx.rpm

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ KWin X11 doesn't see any API changes since version 6.5 meaning the Wayland and X
   ```sh
   yay -S kwin-effects-better-blur-dx-x11
   ```
-  
+
   **`-git` packages tracking the `main` branch:**
 
   Wayland:
@@ -149,7 +149,7 @@ KWin X11 doesn't see any API changes since version 6.5 meaning the Wayland and X
   ```
   sudo pacman -S base-devel git extra-cmake-modules qt6-tools kwin
   ```
-  
+
   X11:
   ```
   sudo pacman -S base-devel git extra-cmake-modules qt6-tools kwin-x11
@@ -164,7 +164,7 @@ KWin X11 doesn't see any API changes since version 6.5 meaning the Wayland and X
   ```
   sudo apt install -y git cmake g++ extra-cmake-modules qt6-tools-dev kwin-dev libkf6configwidgets-dev gettext libkf6crash-dev libkf6globalaccel-dev libkf6kio-dev libkf6service-dev libkf6notifications-dev libkf6kcmutils-dev libkdecorations3-dev libxcb-composite0-dev libxcb-randr0-dev libxcb-shm0-dev libxcb-res0-dev libxcb-sync-dev
   ```
-  
+
   X11:
   ```
   sudo apt install -y git cmake g++ extra-cmake-modules qt6-tools-dev kwin-x11-dev libkf6configwidgets-dev gettext libkf6crash-dev libkf6globalaccel-dev libkf6kio-dev libkf6service-dev libkf6notifications-dev libkf6kcmutils-dev libkdecorations3-dev libxcb-composite0-dev libxcb-randr0-dev libxcb-shm0-dev libxcb-res0-dev libxcb-sync-dev
@@ -179,7 +179,7 @@ KWin X11 doesn't see any API changes since version 6.5 meaning the Wayland and X
   ```
   sudo dnf -y install git cmake extra-cmake-modules gcc-g++ kf6-kwindowsystem-devel plasma-workspace-devel libplasma-devel qt6-qtbase-private-devel qt6-qtbase-devel cmake kwin-devel extra-cmake-modules kwin-devel kf6-knotifications-devel kf6-kio-devel kf6-kcrash-devel kf6-ki18n-devel kf6-kguiaddons-devel libepoxy-devel kf6-kglobalaccel-devel kf6-kcmutils-devel kf6-kconfigwidgets-devel kf6-kdeclarative-devel kdecoration-devel kf6-kglobalaccel kf6-kdeclarative libplasma kf6-kio qt6-qtbase kf6-kguiaddons kf6-ki18n wayland-devel libdrm-devel
   ```
-  
+
   X11:
   ```
   sudo dnf -y install git cmake extra-cmake-modules gcc-g++ kf6-kwindowsystem-devel plasma-workspace-devel libplasma-devel qt6-qtbase-private-devel qt6-qtbase-devel cmake extra-cmake-modules kf6-knotifications-devel kf6-kio-devel kf6-kcrash-devel kf6-ki18n-devel kf6-kguiaddons-devel libepoxy-devel kf6-kglobalaccel-devel kf6-kcmutils-devel kf6-kconfigwidgets-devel kf6-kdeclarative-devel kdecoration-devel kf6-kglobalaccel kf6-kdeclarative libplasma kf6-kio qt6-qtbase kf6-kguiaddons kf6-ki18n wayland-devel libdrm-devel kwin-x11-devel
@@ -194,7 +194,7 @@ KWin X11 doesn't see any API changes since version 6.5 meaning the Wayland and X
   ```
   sudo zypper in -y git cmake-full gcc-c++ kf6-extra-cmake-modules kcoreaddons-devel kguiaddons-devel kconfigwidgets-devel kwindowsystem-devel ki18n-devel kiconthemes-devel kpackage-devel frameworkintegration-devel kcmutils-devel kirigami2-devel "cmake(KF6Config)" "cmake(KF6CoreAddons)" "cmake(KF6FrameworkIntegration)" "cmake(KF6GuiAddons)" "cmake(KF6I18n)" "cmake(KF6KCMUtils)" "cmake(KF6KirigamiPlatform)" "cmake(KF6WindowSystem)" "cmake(Qt6Core)" "cmake(Qt6DBus)" "cmake(Qt6Quick)" "cmake(Qt6Svg)" "cmake(Qt6Widgets)" "cmake(Qt6Xml)" "cmake(Qt6UiTools)" "cmake(KF6Crash)" "cmake(KF6GlobalAccel)" "cmake(KF6KIO)" "cmake(KF6Service)" "cmake(KF6Notifications)" libepoxy-devel kwin6-devel
   ```
-  
+
   X11:
   ```
   sudo zypper in -y git cmake-full gcc-c++ kf6-extra-cmake-modules kcoreaddons-devel kguiaddons-devel kconfigwidgets-devel kwindowsystem-devel ki18n-devel kiconthemes-devel kpackage-devel frameworkintegration-devel kcmutils-devel kirigami2-devel "cmake(KF6Config)" "cmake(KF6CoreAddons)" "cmake(KF6FrameworkIntegration)" "cmake(KF6GuiAddons)" "cmake(KF6I18n)" "cmake(KF6KCMUtils)" "cmake(KF6KirigamiPlatform)" "cmake(KF6WindowSystem)" "cmake(Qt6Core)" "cmake(Qt6DBus)" "cmake(Qt6Quick)" "cmake(Qt6Svg)" "cmake(Qt6Widgets)" "cmake(Qt6Xml)" "cmake(Qt6UiTools)" "cmake(KF6Crash)" "cmake(KF6GlobalAccel)" "cmake(KF6KIO)" "cmake(KF6Service)" "cmake(KF6Notifications)" libepoxy-devel kwin6-x11-devel
@@ -202,38 +202,37 @@ KWin X11 doesn't see any API changes since version 6.5 meaning the Wayland and X
 </details>
 
 ### Building
+
+When building under normal conditions, simply clone the repo and run the included build script.
+
 ```sh
 git clone https://github.com/xarblu/kwin-effects-better-blur-dx
 cd kwin-effects-better-blur-dx
-mkdir build
-cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=/usr
-make -j$(nproc)
-sudo make install
+chmod +x build.sh
+./build.sh
 ```
 
-By default this will build the effect for the regular (Wayland) KWin.
-To build a version for KWin X11 add `-DBBDX_X11=ON` to the `cmake` invocation.
+By default, this will build and install the effect for the regular (Wayland) KWin.
+To build a version for KWin X11, run the script with the `--x11` flag.
 
 <details>
   <summary>Building on Fedora Kinoite</summary>
   <br>
 
+  When building for Fedora Kinoite, run the build script with the `--kinoite` flag inside your container to generate the RPM package.
+
   ```sh
   # enter container
   git clone https://github.com/xarblu/kwin-effects-better-blur-dx
   cd kwin-effects-better-blur-dx
-  mkdir build
-  cd build
-  cmake .. -DCMAKE_INSTALL_PREFIX=/usr
-  make -j$(nproc)
-  cpack -V -G RPM
+  chmod +x build.sh
+  ./build.sh --kinoite
   exit # exit container
   sudo rpm-ostree install kwin-effects-better-blur-dx/build/kwin-better-blur-dx.rpm
   ```
 </details>
 
-**Remove the *build* directory when rebuilding the effect.**
+**Rerun the build script when rebuilding the effect.**
 
 # Usage
 This effect conflicts with the default KWin blur effect (and other effects replacing it).

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,41 @@
+#!/bin/bash
+
+# Specific variables for X11 and Fedora Kinoite
+X11_FLAG=""
+KINOITE_MODE=0
+
+# Parsing arguments
+for arg in "$@"; do
+    if [[ "$arg" == "--x11" ]]; then
+        X11_FLAG="-DBBDX_X11=ON"
+    elif [[ "$arg" == "--kinoite" ]]; then
+        KINOITE_MODE=1
+    elif [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
+        echo "Usage: $0 [OPTIONS]"
+        echo "Options:"
+        echo "  --x11        Build for KWin X11 instead of the Wayland default"
+        echo "  --kinoite    Build an RPM package for Fedora Kinoite"
+        echo "  -h | --help  Displays this message"
+        exit 0
+    else
+        echo "Unknown parameter passed: $arg"
+        exit 1
+    fi
+done
+
+# Common building part of both regular and fedora kinoite versions
 rm -fr build
-mkdir build
-cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+mkdir -p build
+cd build || exit 1
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr $X11_FLAG
 make -j$(nproc)
-sudo make install
+
+# Handle installation or packaging based on the mode
+if [[ $KINOITE_MODE -eq 1 ]]; then
+    cpack -V -G RPM
+
+    echo "To finish installation on Fedora Kinoite, exit your container and run:"
+    echo "sudo rpm-ostree install kwin-effects-better-blur-dx/build/kwin-better-blur-dx.rpm"
+else
+    sudo make install
+fi

--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ done
 # Common building part of both regular and fedora kinoite versions
 rm -fr build
 mkdir -p build
-cd build || exit 1
+cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr $X11_FLAG
 make -j$(nproc)
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Quick help message helper
+print_help() {
+    echo "Usage: $0 [OPTIONS]"
+    echo "Options:"
+    echo "  --x11        Build for KWin X11 instead of the Wayland default"
+    echo "  --kinoite    Build an RPM package for Fedora Kinoite"
+    echo "  -h | --help  Displays this message"
+}
 
 # Specific variables for X11 and Fedora Kinoite
 X11_FLAG=""
@@ -6,21 +15,24 @@ KINOITE_MODE=0
 
 # Parsing arguments
 for arg in "$@"; do
-    if [[ "$arg" == "--x11" ]]; then
-        X11_FLAG="-DBBDX_X11=ON"
-    elif [[ "$arg" == "--kinoite" ]]; then
-        KINOITE_MODE=1
-    elif [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
-        echo "Usage: $0 [OPTIONS]"
-        echo "Options:"
-        echo "  --x11        Build for KWin X11 instead of the Wayland default"
-        echo "  --kinoite    Build an RPM package for Fedora Kinoite"
-        echo "  -h | --help  Displays this message"
-        exit 0
-    else
-        echo "Unknown parameter passed: $arg"
-        exit 1
-    fi
+    case "$arg" in
+        --x11)
+            X11_FLAG="-DBBDX_X11=ON"
+            ;;
+        --kinoite)
+            KINOITE_MODE=1
+            ;;
+        -h|--help)
+            print_help
+            exit 0
+            ;;
+        *)
+            echo "Unknown parameter passed: $arg"
+            echo ""
+            print_help
+            exit 1
+            ;;
+    esac
 done
 
 # Common building part of both regular and fedora kinoite versions


### PR DESCRIPTION
Turns the simple build script I added in the previous PR into something that's actually usable. Handles both X11 and Fedora Kinoite build versions with simple flags, and is easily extensible for any other versions in the future. Ignore the blankspace changes, my IDE just removes trailing ones automatically and I was too lazy to undo them.